### PR TITLE
Fix GitHub Pages asset paths with Vite base URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>CV</title>
-    <link href="/media/cv-screen.css" type="text/css" rel="stylesheet" media="screen" />
-    <link href="/media/cv-print.css" type="text/css" rel="stylesheet" media="print" />
+    <link href="%BASE_URL%media/cv-screen.css" type="text/css" rel="stylesheet" media="screen" />
+    <link href="%BASE_URL%media/cv-print.css" type="text/css" rel="stylesheet" media="print" />
     <script
       src="https://kit.fontawesome.com/774d5c5f58.js"
       crossorigin="anonymous"


### PR DESCRIPTION
## Summary
- update index.html media stylesheet links to use %BASE_URL%
- ensure built output uses repo-aware paths on GitHub Pages subpath deployments

## Why
The deployed site was trying to load root-relative assets, causing 404s when hosted under /nimo-markdown-cv/.

## Validation
- local build passes
- build with GITHUB_ACTIONS=true and GITHUB_REPOSITORY=wodeni/nimo-markdown-cv produces /nimo-markdown-cv/media/... and /nimo-markdown-cv/assets/... paths